### PR TITLE
Implement listing commands for EC2, RDS and Aurora

### DIFF
--- a/internal/service/aurora/ls.go
+++ b/internal/service/aurora/ls.go
@@ -1,0 +1,62 @@
+package aurora
+
+import (
+	"context"
+	"fmt"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+
+	"awstk/internal/service/cfn"
+)
+
+// ListAuroraClusters 現在のリージョンのAuroraクラスター一覧を取得する
+func ListAuroraClusters(rdsClient *rds.Client) ([]AuroraCluster, error) {
+	resp, err := rdsClient.DescribeDBClusters(context.Background(), &rds.DescribeDBClustersInput{})
+	if err != nil {
+		return nil, fmt.Errorf("Auroraクラスター一覧の取得に失敗: %w", err)
+	}
+
+	clusters := make([]AuroraCluster, 0, len(resp.DBClusters))
+	for _, c := range resp.DBClusters {
+		clusters = append(clusters, AuroraCluster{
+			ClusterId: awssdk.ToString(c.DBClusterIdentifier),
+			Engine:    awssdk.ToString(c.Engine),
+			Status:    awssdk.ToString(c.Status),
+		})
+	}
+
+	return clusters, nil
+}
+
+// ListAuroraClustersFromStack 指定されたCloudFormationスタックに属するAuroraクラスター一覧を取得する
+func ListAuroraClustersFromStack(rdsClient *rds.Client, cfnClient *cloudformation.Client, stackName string) ([]AuroraCluster, error) {
+	ids, err := cfn.GetAllAuroraFromStack(cfnClient, stackName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ids) == 0 {
+		return []AuroraCluster{}, nil
+	}
+
+	all, err := ListAuroraClusters(rdsClient)
+	if err != nil {
+		return nil, err
+	}
+
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+
+	var clusters []AuroraCluster
+	for _, cl := range all {
+		if _, ok := idSet[cl.ClusterId]; ok {
+			clusters = append(clusters, cl)
+		}
+	}
+
+	return clusters, nil
+}

--- a/internal/service/aurora/types.go
+++ b/internal/service/aurora/types.go
@@ -1,0 +1,8 @@
+package aurora
+
+// AuroraCluster Auroraクラスターの情報を格納する構造体
+type AuroraCluster struct {
+	ClusterId string
+	Engine    string
+	Status    string
+}

--- a/internal/service/rds/ls.go
+++ b/internal/service/rds/ls.go
@@ -1,0 +1,62 @@
+package rds
+
+import (
+	"context"
+	"fmt"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+
+	"awstk/internal/service/cfn"
+)
+
+// ListRdsInstances 現在のリージョンのRDSインスタンス一覧を取得する
+func ListRdsInstances(rdsClient *rds.Client) ([]RdsInstance, error) {
+	resp, err := rdsClient.DescribeDBInstances(context.Background(), &rds.DescribeDBInstancesInput{})
+	if err != nil {
+		return nil, fmt.Errorf("RDSインスタンス一覧の取得に失敗: %w", err)
+	}
+
+	instances := make([]RdsInstance, 0, len(resp.DBInstances))
+	for _, db := range resp.DBInstances {
+		instances = append(instances, RdsInstance{
+			InstanceId: awssdk.ToString(db.DBInstanceIdentifier),
+			Engine:     awssdk.ToString(db.Engine),
+			Status:     awssdk.ToString(db.DBInstanceStatus),
+		})
+	}
+
+	return instances, nil
+}
+
+// ListRdsInstancesFromStack 指定されたCloudFormationスタックに属するRDSインスタンス一覧を取得する
+func ListRdsInstancesFromStack(rdsClient *rds.Client, cfnClient *cloudformation.Client, stackName string) ([]RdsInstance, error) {
+	ids, err := cfn.GetAllRdsFromStack(cfnClient, stackName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ids) == 0 {
+		return []RdsInstance{}, nil
+	}
+
+	all, err := ListRdsInstances(rdsClient)
+	if err != nil {
+		return nil, err
+	}
+
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+
+	var instances []RdsInstance
+	for _, ins := range all {
+		if _, ok := idSet[ins.InstanceId]; ok {
+			instances = append(instances, ins)
+		}
+	}
+
+	return instances, nil
+}

--- a/internal/service/rds/types.go
+++ b/internal/service/rds/types.go
@@ -1,0 +1,8 @@
+package rds
+
+// RdsInstance RDSインスタンスの情報を格納する構造体
+type RdsInstance struct {
+	InstanceId string
+	Engine     string
+	Status     string
+}


### PR DESCRIPTION
## Summary
- add listing logic for RDS instances and Aurora clusters
- expose `ec2 ls`, `rds ls`, and `aurora ls` commands
- allow filtering by CloudFormation stack via `-S`
- initialize CloudFormation client for EC2 commands
- move listing command logic to service layer
- fix duplicate not-found checks
- simplify not-found messages in listing commands

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6857c92bd5e48321a82d6a9a4f4e86a7