### PR TITLE
Rename showActiveStacks variable to activeOnly

### DIFF
--- a/cmd/cfn.go
+++ b/cmd/cfn.go
@@ -18,6 +18,8 @@ var CfnCmd = &cobra.Command{
 	Long:  `CloudFormationリソースを操作するためのコマンド群です。`,
 }
 
+var activeOnly bool
+
 var cfnLsCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "CloudFormationスタック一覧を表示するコマンド",
@@ -25,7 +27,7 @@ var cfnLsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfnClient := cloudformation.NewFromConfig(awsCfg)
 
-		stackNames, err := cfn.ListCfnStacks(cfnClient)
+		stackNames, err := cfn.ListCfnStacks(cfnClient, activeOnly)
 		if err != nil {
 			return fmt.Errorf("❌ CloudFormationスタック一覧取得でエラー: %w", err)
 		}
@@ -142,4 +144,7 @@ func init() {
 	// cfn start/stopコマンド用のフラグ
 	cfnStartCmd.Flags().StringP("stack", "S", "", "CloudFormationスタック名")
 	cfnStopCmd.Flags().StringP("stack", "S", "", "CloudFormationスタック名")
+
+	// cfn lsコマンド用のフラグ
+	cfnLsCmd.Flags().BoolVarP(&activeOnly, "active", "a", false, "アクティブなスタックのみ表示")
 }

--- a/internal/service/cfn/ls.go
+++ b/internal/service/cfn/ls.go
@@ -9,8 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 )
 
-// ListCfnStacks はアクティブなCloudFormationスタック名一覧を返す
-func ListCfnStacks(cfnClient *cloudformation.Client) ([]string, error) {
+// ListCfnStacks はCloudFormationスタック名一覧を返す。
+// activeOnly が true の場合、アクティブなスタックのみを対象とする。
+func ListCfnStacks(cfnClient *cloudformation.Client, activeOnly bool) ([]string, error) {
 	activeStatusStrs := []string{
 		"CREATE_COMPLETE",
 		"UPDATE_COMPLETE",
@@ -32,8 +33,10 @@ func ListCfnStacks(cfnClient *cloudformation.Client) ([]string, error) {
 	// すべてのページを取得するまでループ
 	for {
 		input := &cloudformation.ListStacksInput{
-			StackStatusFilter: activeStatuses,
-			NextToken:         nextToken,
+			NextToken: nextToken,
+		}
+		if activeOnly {
+			input.StackStatusFilter = activeStatuses
 		}
 
 		resp, err := cfnClient.ListStacks(context.Background(), input)


### PR DESCRIPTION
## Summary
- add `activeOnly` flag for `cfn ls`
- pass the flag to service layer
- update service function to accept the flag

## Testing
- `gofmt -w cmd/cfn.go internal/service/cfn/ls.go`
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68595474bbe08321acc7774f4ec82963